### PR TITLE
Try to convert if possible, instead of just panicing

### DIFF
--- a/automapper.go
+++ b/automapper.go
@@ -81,7 +81,7 @@ func mapValues(sourceVal, destVal reflect.Value, loose bool) {
 	} else if destType.Kind() == reflect.Slice {
 		mapSlice(sourceVal, destVal, loose)
 	} else {
-		panic("Currently not supported")
+		destVal.Set(sourceVal.Convert(destType))
 	}
 }
 

--- a/automapper_test.go
+++ b/automapper_test.go
@@ -256,6 +256,19 @@ func TestWithLooseOption(t *testing.T) {
 	assert.Equal(t, dest.Bar, 0)
 }
 
+func TestNamedType(t *testing.T) {
+	type SourceType string
+	type DestType string
+	source := struct {
+		Foo SourceType
+	}{"abc"}
+	dest := struct {
+		Foo DestType
+	}{}
+	Map(&source, &dest)
+	assert.Equal(t, string(source.Foo), string(dest.Foo))
+}
+
 type SourceParent struct {
 	Children []SourceTypeA
 }


### PR DESCRIPTION
Try to convert if possible, instead of just panicing with "Currently not supported".

Convert will panic anyway if the conversion is not possible, and this way we support mapping of types that _can_ be converted.