### PR TITLE
Allow directly mapping of structs that are of the same type.

### DIFF
--- a/automapper.go
+++ b/automapper.go
@@ -58,7 +58,7 @@ func MapLoose(source, dest interface{}) {
 
 func mapValues(sourceVal, destVal reflect.Value, loose bool) {
 	destType := destVal.Type()
-	if destType.Kind() == reflect.Struct {
+	if destType.Kind() == reflect.Struct && sourceVal.Type() != destVal.Type() {
 		if sourceVal.Type().Kind() == reflect.Ptr {
 			if sourceVal.IsNil() {
 				// If source is nil, it maps to an empty struct

--- a/automapper_test.go
+++ b/automapper_test.go
@@ -3,9 +3,9 @@
 package automapper
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func TestPanicWhenDestIsNotPointer(t *testing.T) {
@@ -254,6 +254,20 @@ func TestWithLooseOption(t *testing.T) {
 	MapLoose(&source, &dest)
 	assert.Equal(t, dest.Foo, "Foo")
 	assert.Equal(t, dest.Bar, 0)
+}
+
+func TestSetStructOfSameTypeDirectly(t *testing.T) {
+	type FooType struct {
+		time.Time
+	}
+	source := struct {
+		Foo FooType
+	}{FooType{Time: time.Now().UTC()}}
+	dest := struct {
+		Foo FooType
+	}{}
+	Map(&source, &dest)
+	assert.Equal(t, source.Foo.String(), dest.Foo.String())
 }
 
 type SourceParent struct {


### PR DESCRIPTION
Some structs cannot be mapped by simply traversing the fields, because they simply don't export any. For example `time.Time`. 

This allows these structs to be set by checking if the source and destination type is the same and if they are, set the struct directly.